### PR TITLE
Fixing JS watch blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Your final build script should resemble this.
     "watch": "run-p watch:* ",
     "watch:html": "watch -p \"src/*.html\" -c \"npm run copy-html\" ",
     "watch:css": "watch -p \"src/scss/*.scss\" -c \"npm run compile-css\" ",
-    "watch:js": "watch -p \"src/js/**.js\" -c \"npm run compile-js\" "
+    "watch:js": "watch -p \"src/js/**/*.js\" -c \"npm run compile-js\" "
   },
   "repository": {
     "type": "git",

--- a/finished/package.json
+++ b/finished/package.json
@@ -17,7 +17,7 @@
     "watch": "run-p watch:* ",
     "watch:html": "watch -p \"src/*.html\" -c \"npm run copy-html\" ",
     "watch:css": "watch -p \"src/scss/*.scss\" -c \"npm run compile-css\" ",
-    "watch:js": "watch -p \"src/js/**.js\" -c \"npm run compile-js\" "
+    "watch:js": "watch -p \"src/js/**/*.js\" -c \"npm run compile-js\" "
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
With the current example, the JS watch blob doesn't hit the modules directory. 

```modules/module_one.js```